### PR TITLE
Added in game config options using fzzy config mod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ repositories {
 		name = "Ladysnake Libs"
 		url = 'https://maven.ladysnake.org/releases'
 	}
+	maven {
+		name = "FzzyMaven"
+		url = "https://maven.fzzyhmstrs.me/"
+	}
 }
 
 fabricApi {
@@ -40,14 +44,19 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 
-	modImplementation "dev.emi:trinkets:3.10.0"
+	modImplementation "dev.emi:trinkets:${project.trinkets_version}"
+	modImplementation "me.fzzyhmstrs:fzzy_config:${project.fzzy_config_version}"
 }
 
 processResources {
 	inputs.property "version", project.version
+	inputs.property "trinkets_version", project.trinkets_version
+	inputs.property "fzzy_config_version", project.fzzy_config_version
 
 	filesMatching("fabric.mod.json") {
-		expand "version": project.version
+		expand "version": project.version,
+				"trinkets_version": project.trinkets_version,
+				"fzzy_config_version": project.fzzy_config_version
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ archives_base_name=hazels-various-wings
 
 # Dependencies
 fabric_version=0.104.0+1.21.1
+trinkets_version=3.10.0
+fzzy_config_version=0.6.4+1.21

--- a/src/main/java/hazelclover/hazelsvariouswings/HazelsVariousWings.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/HazelsVariousWings.java
@@ -1,12 +1,12 @@
 package hazelclover.hazelsvariouswings;
 
-import hazelclover.hazelsvariouswings.fuctionality.WingsHandler;
+import hazelclover.hazelsvariouswings.config.GeneralConfig;
+import hazelclover.hazelsvariouswings.config.WingsConfig;
 import hazelclover.hazelsvariouswings.item.ModItemGroup;
 import hazelclover.hazelsvariouswings.item.ModItems;
 import hazelclover.hazelsvariouswings.loot.LootInjector;
 import hazelclover.hazelsvariouswings.loot.TraderTrades;
 import net.fabricmc.api.ModInitializer;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +16,8 @@ public class HazelsVariousWings implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
+		GeneralConfig.init();
+		WingsConfig.init();
 		ModItemGroup.registerItemGroups();
 		ModItems.registerModItems();
 		TraderTrades.register();

--- a/src/main/java/hazelclover/hazelsvariouswings/HazelsVariousWingsDataGenerator.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/HazelsVariousWingsDataGenerator.java
@@ -1,11 +1,14 @@
 package hazelclover.hazelsvariouswings;
 
+import hazelclover.hazelsvariouswings.item.ModTags;
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 
 public class HazelsVariousWingsDataGenerator implements DataGeneratorEntrypoint {
 	@Override
 	public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
-
+		FabricDataGenerator.Pack pack = fabricDataGenerator.createPack();
+		pack.addProvider(ModTags::new);
 	}
+
 }

--- a/src/main/java/hazelclover/hazelsvariouswings/config/GeneralConfig.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/config/GeneralConfig.java
@@ -2,15 +2,15 @@ package hazelclover.hazelsvariouswings.config;
 
 import hazelclover.hazelsvariouswings.HazelsVariousWings;
 import hazelclover.hazelsvariouswings.item.ModTags;
-import me.fzzyhmstrs.fzzy_config.annotations.Action;
 import me.fzzyhmstrs.fzzy_config.annotations.Comment;
-import me.fzzyhmstrs.fzzy_config.annotations.RequiresAction;
 import me.fzzyhmstrs.fzzy_config.annotations.Version;
 import me.fzzyhmstrs.fzzy_config.api.ConfigApiJava;
 import me.fzzyhmstrs.fzzy_config.config.Config;
 import me.fzzyhmstrs.fzzy_config.validation.minecraft.ValidatedIdentifier;
 import me.fzzyhmstrs.fzzy_config.validation.misc.ValidatedBoolean;
 import me.fzzyhmstrs.fzzy_config.validation.misc.ValidatedCondition;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
 @SuppressWarnings({"CanBeFinal", "unused"})
@@ -28,7 +28,12 @@ public class GeneralConfig extends Config {
     }
 
     @Comment("If true, the vanilla elytra will be disabled and only be used for crafting.")
-    public boolean disableVanillaElytra = false;
+    public ValidatedBoolean disableVanillaElytra = new ValidatedBoolean(false);
+
+    @Comment("""
+            If false, fireworks can't be used to boost the player while flying with vanilla elytra.
+            Note: this option is only used if the vanilla elytra is enabled.""")
+    public ValidatedCondition<Boolean> canUseFireworks = new ValidatedBoolean(true).toCondition(() -> !disableVanillaElytra.get(), Text.literal("Vanilla Elytra must be enabled").formatted(Formatting.AQUA), () -> false);
 
     @Comment("""
             If true, the elytra will be replaced with the wings specified in the 'replaceElytraInEndCityShipWith' option.
@@ -38,7 +43,7 @@ public class GeneralConfig extends Config {
     @Comment("""
             The wings that will replace the elytra in the End City Ship. Only used if 'replaceElytraInEndCityShip' is true.
             Note: already generated End City Ships will not be affected.""")
-    public ValidatedCondition<Identifier> replaceElytraInEndCityShipWith = (ValidatedIdentifier.ofTag(Identifier.of(HazelsVariousWings.MOD_ID, "elytra_wings"), ModTags.WINGS)).toCondition(replaceElytraInEndCityShip, () -> Identifier.of(HazelsVariousWings.MOD_ID, "elytra_wings"));
+    public ValidatedCondition<Identifier> replaceElytraInEndCityShipWith = (ValidatedIdentifier.ofTag(Identifier.of(HazelsVariousWings.MOD_ID, "elytra_wings"), ModTags.WINGS)).toCondition(replaceElytraInEndCityShip, Text.literal("Replace Elytra In End City Ship must be true").formatted(Formatting.AQUA), () -> Identifier.of(HazelsVariousWings.MOD_ID, "elytra_wings"));
 
     @Override
     public int defaultPermLevel() {

--- a/src/main/java/hazelclover/hazelsvariouswings/config/GeneralConfig.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/config/GeneralConfig.java
@@ -1,0 +1,47 @@
+package hazelclover.hazelsvariouswings.config;
+
+import hazelclover.hazelsvariouswings.HazelsVariousWings;
+import hazelclover.hazelsvariouswings.item.ModTags;
+import me.fzzyhmstrs.fzzy_config.annotations.Action;
+import me.fzzyhmstrs.fzzy_config.annotations.Comment;
+import me.fzzyhmstrs.fzzy_config.annotations.RequiresAction;
+import me.fzzyhmstrs.fzzy_config.annotations.Version;
+import me.fzzyhmstrs.fzzy_config.api.ConfigApiJava;
+import me.fzzyhmstrs.fzzy_config.config.Config;
+import me.fzzyhmstrs.fzzy_config.validation.minecraft.ValidatedIdentifier;
+import me.fzzyhmstrs.fzzy_config.validation.misc.ValidatedBoolean;
+import me.fzzyhmstrs.fzzy_config.validation.misc.ValidatedCondition;
+import net.minecraft.util.Identifier;
+
+@SuppressWarnings({"CanBeFinal", "unused"})
+@Version(version = 1)
+public class GeneralConfig extends Config {
+
+    public static GeneralConfig INSTANCE;
+
+    public GeneralConfig() {
+        super(Identifier.of(HazelsVariousWings.MOD_ID, "config"));
+    }
+
+    public static void init() {
+        INSTANCE = ConfigApiJava.registerAndLoadConfig(GeneralConfig::new);
+    }
+
+    @Comment("If true, the vanilla elytra will be disabled and only be used for crafting.")
+    public boolean disableVanillaElytra = false;
+
+    @Comment("""
+            If true, the elytra will be replaced with the wings specified in the 'replaceElytraInEndCityShipWith' option.
+            Note: already generated End City Ships will not be affected.""")
+    public ValidatedBoolean replaceElytraInEndCityShip = new ValidatedBoolean(true);
+
+    @Comment("""
+            The wings that will replace the elytra in the End City Ship. Only used if 'replaceElytraInEndCityShip' is true.
+            Note: already generated End City Ships will not be affected.""")
+    public ValidatedCondition<Identifier> replaceElytraInEndCityShipWith = (ValidatedIdentifier.ofTag(Identifier.of(HazelsVariousWings.MOD_ID, "elytra_wings"), ModTags.WINGS)).toCondition(replaceElytraInEndCityShip, () -> Identifier.of(HazelsVariousWings.MOD_ID, "elytra_wings"));
+
+    @Override
+    public int defaultPermLevel() {
+        return 3;
+    }
+}

--- a/src/main/java/hazelclover/hazelsvariouswings/config/WingsConfig.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/config/WingsConfig.java
@@ -1,0 +1,97 @@
+package hazelclover.hazelsvariouswings.config;
+
+import hazelclover.hazelsvariouswings.HazelsVariousWings;
+import me.fzzyhmstrs.fzzy_config.annotations.Action;
+import me.fzzyhmstrs.fzzy_config.annotations.RequiresAction;
+import me.fzzyhmstrs.fzzy_config.annotations.TomlHeaderComment;
+import me.fzzyhmstrs.fzzy_config.annotations.Version;
+import me.fzzyhmstrs.fzzy_config.api.ConfigApiJava;
+import me.fzzyhmstrs.fzzy_config.config.Config;
+import me.fzzyhmstrs.fzzy_config.config.ConfigSection;
+import me.fzzyhmstrs.fzzy_config.validation.number.ValidatedFloat;
+import me.fzzyhmstrs.fzzy_config.validation.number.ValidatedInt;
+import net.minecraft.util.Identifier;
+
+// FIXME: This headers doesn't seem to work
+@SuppressWarnings("CanBeFinal")
+@TomlHeaderComment(text = """
+        This is the config file for the wings in Hazel's Various Wings.
+        Here you can change the durability, scale, and power of each wing.
+        You can also enable or disable the wings' functionality in water and gliding.
+        If you change the durability of a wing, you will need to restart the game for the changes to take effect.
+        Properties:
+        - durability: The durability of the wing.
+        - scale: The scale of the wing.
+        - flyDuration: The duration of the wing's flight.
+        - flyPower: The power of the wing's flight.
+        - hoverDuration: The duration of the wing's hover.
+        - hoverPower: The power of the wing's hover.
+        - inWaterFunctional: If the wing is functional in water.
+        - doesGlide: If the wing can glide.""")
+@Version(version = 1)
+public class WingsConfig extends Config {
+
+    public static WingsConfig INSTANCE;
+
+    public WingConfig flimsyWings = new WingConfig(54, 0.7f, 0.3f, 0.2f, 0f, 0f, false, false);
+    public WingConfig fledglingWings = new WingConfig(47, 0.8f, 0f, 0f, 0.3f, 0.2f, false, false);
+    public WingConfig phantomWings = new WingConfig(130, 1f, 0.3f, 0.29f, 0f, 0f, false, false);
+    public WingConfig leafWings = new WingConfig(122, 0.9f, 0.3f, 0.28f, 0.6f, 0.2f, false, false);
+    public WingConfig coralWings = new WingConfig(370, 1f, 0.6f, 0.22f, 2f, 0.22f, true, false);
+    public WingConfig beeWings = new WingConfig(235, 0.8f, 0.36f, 0.22f, 1.8f, 0.18f, false, false);
+    public WingConfig mothWings = new WingConfig(324, 1f, 0.66f, 0.24f, 0.8f, 0.16f, false, false);
+    public WingConfig demonWings = new WingConfig(145, 1.1f, 0.35f, 0.22f, 1.4f, 0.2f, false, false);
+    public WingConfig blazeWings = new WingConfig(478, 1.3f, 0.5f, 0.32f, 2.2f, 0.17f, false, false);
+    public WingConfig gemWings = new WingConfig(611, 1.2f, 0.4f, 0.28f, 0.7f, 0.2f, false, false);
+    public WingConfig voidWings = new WingConfig(1100, 1.3f, 0.72f, 0.34f, 1.8f, 0.14f, false, false);
+    public WingConfig elytraWings = new WingConfig(1620, 1.1f, 0f, 0f, 0f, 0f, false, true);
+    public WingConfig pristineWings = new WingConfig(2120, 1.5f, 1.4f, 0.41f, 4f, 0.16f, true, true);
+    public WingConfig nebulousWings = new WingConfig(2034, 1.65f, 1.84f, 0.502f, 9999f, 0.1f, true, false);
+    public WingConfig aslerixWings = new WingConfig(2170, 1.6f, 2.1f, 0.3f, 9999f, 0.11f, true, true);
+    public WingConfig hazelWings = new WingConfig(2140, 1.6f, 1.02f, 0.47f, 2f, 0.17f, true, true);
+    public WingConfig mechanicalWings = new WingConfig(220, 1.1f, 0.5f, 0.26f, 1.2f, 0.17f, false, false);
+    public WingConfig brassWings = new WingConfig(2300, 1.55f, 9f, 0.3f, 9999f, 0.2f, true, false);
+
+    public WingsConfig() {
+        super(Identifier.of(HazelsVariousWings.MOD_ID, "wings_config"));
+    }
+
+    public static void init() {
+        INSTANCE = ConfigApiJava.registerAndLoadConfig(WingsConfig::new);
+    }
+
+    public static class WingConfig extends ConfigSection {
+        @RequiresAction(action = Action.RESTART)
+        @ValidatedInt.Restrict(min = 1)
+        public int durability;
+        @ValidatedFloat.Restrict(min = 0)
+        public float scale;
+        @ValidatedFloat.Restrict(min = 0)
+        public float flyDuration;
+        @ValidatedFloat.Restrict(min = 0)
+        public float flyPower;
+        @ValidatedFloat.Restrict(min = 0)
+        public float hoverDuration;
+        @ValidatedFloat.Restrict(min = 0)
+        public float hoverPower;
+        // TODO: Actually make this work?
+        public boolean inWaterFunctional;
+        public boolean doesGlide;
+
+        public WingConfig(int durability, float scale, float flyDuration, float flyPower, float hoverDuration, float hoverPower, boolean inWaterFunctional, boolean doesGlide) {
+            this.durability = durability;
+            this.scale = scale;
+            this.flyDuration = flyDuration;
+            this.flyPower = flyPower;
+            this.hoverDuration = hoverDuration;
+            this.hoverPower = hoverPower;
+            this.inWaterFunctional = inWaterFunctional;
+            this.doesGlide = doesGlide;
+        }
+    }
+
+    @Override
+    public int defaultPermLevel() {
+        return 3;
+    }
+}

--- a/src/main/java/hazelclover/hazelsvariouswings/config/WingsConfig.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/config/WingsConfig.java
@@ -1,15 +1,16 @@
 package hazelclover.hazelsvariouswings.config;
 
 import hazelclover.hazelsvariouswings.HazelsVariousWings;
-import me.fzzyhmstrs.fzzy_config.annotations.Action;
-import me.fzzyhmstrs.fzzy_config.annotations.RequiresAction;
-import me.fzzyhmstrs.fzzy_config.annotations.TomlHeaderComment;
-import me.fzzyhmstrs.fzzy_config.annotations.Version;
+import me.fzzyhmstrs.fzzy_config.annotations.*;
 import me.fzzyhmstrs.fzzy_config.api.ConfigApiJava;
 import me.fzzyhmstrs.fzzy_config.config.Config;
 import me.fzzyhmstrs.fzzy_config.config.ConfigSection;
+import me.fzzyhmstrs.fzzy_config.validation.misc.ValidatedBoolean;
+import me.fzzyhmstrs.fzzy_config.validation.misc.ValidatedCondition;
 import me.fzzyhmstrs.fzzy_config.validation.number.ValidatedFloat;
 import me.fzzyhmstrs.fzzy_config.validation.number.ValidatedInt;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
 // FIXME: This headers doesn't seem to work
@@ -33,24 +34,24 @@ public class WingsConfig extends Config {
 
     public static WingsConfig INSTANCE;
 
-    public WingConfig flimsyWings = new WingConfig(54, 0.7f, 0.3f, 0.2f, 0f, 0f, false, false);
-    public WingConfig fledglingWings = new WingConfig(47, 0.8f, 0f, 0f, 0.3f, 0.2f, false, false);
-    public WingConfig phantomWings = new WingConfig(130, 1f, 0.3f, 0.29f, 0f, 0f, false, false);
-    public WingConfig leafWings = new WingConfig(122, 0.9f, 0.3f, 0.28f, 0.6f, 0.2f, false, false);
-    public WingConfig coralWings = new WingConfig(370, 1f, 0.6f, 0.22f, 2f, 0.22f, true, false);
-    public WingConfig beeWings = new WingConfig(235, 0.8f, 0.36f, 0.22f, 1.8f, 0.18f, false, false);
-    public WingConfig mothWings = new WingConfig(324, 1f, 0.66f, 0.24f, 0.8f, 0.16f, false, false);
-    public WingConfig demonWings = new WingConfig(145, 1.1f, 0.35f, 0.22f, 1.4f, 0.2f, false, false);
-    public WingConfig blazeWings = new WingConfig(478, 1.3f, 0.5f, 0.32f, 2.2f, 0.17f, false, false);
-    public WingConfig gemWings = new WingConfig(611, 1.2f, 0.4f, 0.28f, 0.7f, 0.2f, false, false);
-    public WingConfig voidWings = new WingConfig(1100, 1.3f, 0.72f, 0.34f, 1.8f, 0.14f, false, false);
-    public WingConfig elytraWings = new WingConfig(1620, 1.1f, 0f, 0f, 0f, 0f, false, true);
-    public WingConfig pristineWings = new WingConfig(2120, 1.5f, 1.4f, 0.41f, 4f, 0.16f, true, true);
-    public WingConfig nebulousWings = new WingConfig(2034, 1.65f, 1.84f, 0.502f, 9999f, 0.1f, true, false);
-    public WingConfig aslerixWings = new WingConfig(2170, 1.6f, 2.1f, 0.3f, 9999f, 0.11f, true, true);
-    public WingConfig hazelWings = new WingConfig(2140, 1.6f, 1.02f, 0.47f, 2f, 0.17f, true, true);
-    public WingConfig mechanicalWings = new WingConfig(220, 1.1f, 0.5f, 0.26f, 1.2f, 0.17f, false, false);
-    public WingConfig brassWings = new WingConfig(2300, 1.55f, 9f, 0.3f, 9999f, 0.2f, true, false);
+    public WingConfig flimsyWings = new WingConfig(54, 0.7f, 0.3f, 0.2f, 0f, 0f, false, false, false);
+    public WingConfig fledglingWings = new WingConfig(47, 0.8f, 0f, 0f, 0.3f, 0.2f, false, false, false);
+    public WingConfig phantomWings = new WingConfig(130, 1f, 0.3f, 0.29f, 0f, 0f, false, false, false);
+    public WingConfig leafWings = new WingConfig(122, 0.9f, 0.3f, 0.28f, 0.6f, 0.2f, false, false, false);
+    public WingConfig coralWings = new WingConfig(370, 1f, 0.6f, 0.22f, 2f, 0.22f, true, false, false);
+    public WingConfig beeWings = new WingConfig(235, 0.8f, 0.36f, 0.22f, 1.8f, 0.18f, false, false, false);
+    public WingConfig mothWings = new WingConfig(324, 1f, 0.66f, 0.24f, 0.8f, 0.16f, false, false, false);
+    public WingConfig demonWings = new WingConfig(145, 1.1f, 0.35f, 0.22f, 1.4f, 0.2f, false, false, false);
+    public WingConfig blazeWings = new WingConfig(478, 1.3f, 0.5f, 0.32f, 2.2f, 0.17f, false, false, false);
+    public WingConfig gemWings = new WingConfig(611, 1.2f, 0.4f, 0.28f, 0.7f, 0.2f, false, false, false);
+    public WingConfig voidWings = new WingConfig(1100, 1.3f, 0.72f, 0.34f, 1.8f, 0.14f, false, false, false);
+    public WingConfig elytraWings = new WingConfig(1620, 1.1f, 0f, 0f, 0f, 0f, false, true, true);
+    public WingConfig pristineWings = new WingConfig(2120, 1.5f, 1.4f, 0.41f, 4f, 0.16f, true, true, false);
+    public WingConfig nebulousWings = new WingConfig(2034, 1.65f, 1.84f, 0.502f, 9999f, 0.1f, true, false, false);
+    public WingConfig aslerixWings = new WingConfig(2170, 1.6f, 2.1f, 0.3f, 9999f, 0.11f, true, true, false);
+    public WingConfig hazelWings = new WingConfig(2140, 1.6f, 1.02f, 0.47f, 2f, 0.17f, true, true, false);
+    public WingConfig mechanicalWings = new WingConfig(220, 1.1f, 0.5f, 0.26f, 1.2f, 0.17f, false, false, false);
+    public WingConfig brassWings = new WingConfig(2300, 1.55f, 9f, 0.3f, 9999f, 0.2f, true, false, false);
 
     public WingsConfig() {
         super(Identifier.of(HazelsVariousWings.MOD_ID, "wings_config"));
@@ -75,10 +76,16 @@ public class WingsConfig extends Config {
         @ValidatedFloat.Restrict(min = 0)
         public float hoverPower;
         // TODO: Actually make this work?
+        @Comment("If true, the wing can be used in water.")
         public boolean inWaterFunctional;
-        public boolean doesGlide;
+        @Comment("If true, the wing can be used to glide.")
+        public ValidatedBoolean doesGlide;
+        @Comment("""
+            If true, fireworks can be used while gliding with this wing to increase speed, just like with the vanilla elytra.
+            Note: This only works if the wing can glide.""")
+        public ValidatedCondition<Boolean> canUseFireworks;
 
-        public WingConfig(int durability, float scale, float flyDuration, float flyPower, float hoverDuration, float hoverPower, boolean inWaterFunctional, boolean doesGlide) {
+        public WingConfig(int durability, float scale, float flyDuration, float flyPower, float hoverDuration, float hoverPower, boolean inWaterFunctional, boolean doesGlide, boolean canUseFireworks) {
             this.durability = durability;
             this.scale = scale;
             this.flyDuration = flyDuration;
@@ -86,7 +93,8 @@ public class WingsConfig extends Config {
             this.hoverDuration = hoverDuration;
             this.hoverPower = hoverPower;
             this.inWaterFunctional = inWaterFunctional;
-            this.doesGlide = doesGlide;
+            this.doesGlide = new ValidatedBoolean(doesGlide);
+            this.canUseFireworks = new ValidatedBoolean(canUseFireworks).toCondition(this.doesGlide, Text.literal("Does Glide must be true").formatted(Formatting.AQUA), () -> canUseFireworks);
         }
     }
 

--- a/src/main/java/hazelclover/hazelsvariouswings/fuctionality/WingsHandler.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/fuctionality/WingsHandler.java
@@ -41,8 +41,8 @@ public class WingsHandler {
                 player.stopFallFlying();
                 wings.startGlideOnServer = false;
             }
-            wings.currentFlyDuration = wings.flyDuration;
-            wings.currentHoverDuration = wings.hoverDuration;
+            wings.currentFlyDuration = wings.config.flyDuration;
+            wings.currentHoverDuration = wings.config.hoverDuration;
         }
 
         if (player.isFallFlying()) {
@@ -55,7 +55,7 @@ public class WingsHandler {
             onSpaceHeld((ClientPlayerEntity) player, wings, isInvOpen);
             if (!isInvOpen) wings.flightHeldTicks++;
         } else if (!isInvOpen) {
-            if (wings.doesGlide && wings.flightHeldTicks > 0 && wings.flightHeldTicks < 4 && !isInWater) {
+            if (wings.config.doesGlide && wings.flightHeldTicks > 0 && wings.flightHeldTicks < 4 && !isInWater) {
                 wings.startGlideOnServer = true;
                 wings.pastGlideSpeed = (float) player.getVelocity().length();
             }
@@ -65,14 +65,14 @@ public class WingsHandler {
 
     private static void onSpaceHeld(ClientPlayerEntity player, WingsItem wings, boolean isInvOpen) {
         if (!isInvOpen && wings.currentFlyDuration > 0) {
-            player.fallDistance /= wings.flyPower + 1;
-            player.setVelocity(player.getVelocity().x, Math.min(player.getVelocity().y + wings.flyPower * 0.4f, wings.flyPower), player.getVelocity().z);
+            player.fallDistance /= wings.config.flyPower + 1;
+            player.setVelocity(player.getVelocity().x, Math.min(player.getVelocity().y + wings.config.flyPower * 0.4f, wings.config.flyPower), player.getVelocity().z);
             wings.currentFlyDuration -= 0.05f;
             wings.damageItemTimer -= 0.045f;
             wings.flightState = WingsFlightState.UP;
         } else if (wings.currentHoverDuration > 0 && player.getVelocity().y < 0) {
-            player.fallDistance *= wings.hoverPower * 4.2f;
-            player.setVelocity(player.getVelocity().x, Math.max(player.getVelocity().y + (0.3f - wings.hoverPower), -wings.hoverPower), player.getVelocity().z);
+            player.fallDistance *= wings.config.hoverPower * 4.2f;
+            player.setVelocity(player.getVelocity().x, Math.max(player.getVelocity().y + (0.3f - wings.config.hoverPower), -wings.config.hoverPower), player.getVelocity().z);
             wings.currentHoverDuration -= 0.05f;
             wings.damageItemTimer -= 0.025f;
             wings.flightState = WingsFlightState.HOVER;

--- a/src/main/java/hazelclover/hazelsvariouswings/fuctionality/WingsHandler.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/fuctionality/WingsHandler.java
@@ -55,7 +55,7 @@ public class WingsHandler {
             onSpaceHeld((ClientPlayerEntity) player, wings, isInvOpen);
             if (!isInvOpen) wings.flightHeldTicks++;
         } else if (!isInvOpen) {
-            if (wings.config.doesGlide && wings.flightHeldTicks > 0 && wings.flightHeldTicks < 4 && !isInWater) {
+            if (wings.config.doesGlide.get() && wings.flightHeldTicks > 0 && wings.flightHeldTicks < 4 && !isInWater) {
                 wings.startGlideOnServer = true;
                 wings.pastGlideSpeed = (float) player.getVelocity().length();
             }
@@ -70,9 +70,9 @@ public class WingsHandler {
             wings.currentFlyDuration -= 0.05f;
             wings.damageItemTimer -= 0.045f;
             wings.flightState = WingsFlightState.UP;
-        } else if (wings.currentHoverDuration > 0 && player.getVelocity().y < 0) {
+        } else if (wings.currentHoverDuration > 0) {
             player.fallDistance *= wings.config.hoverPower * 4.2f;
-            player.setVelocity(player.getVelocity().x, Math.max(player.getVelocity().y + (0.3f - wings.config.hoverPower), -wings.config.hoverPower), player.getVelocity().z);
+            player.setVelocity(player.getVelocity().x, 0, player.getVelocity().z);
             wings.currentHoverDuration -= 0.05f;
             wings.damageItemTimer -= 0.025f;
             wings.flightState = WingsFlightState.HOVER;

--- a/src/main/java/hazelclover/hazelsvariouswings/item/ModItems.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/item/ModItems.java
@@ -1,6 +1,7 @@
 package hazelclover.hazelsvariouswings.item;
 
 import hazelclover.hazelsvariouswings.HazelsVariousWings;
+import hazelclover.hazelsvariouswings.config.WingsConfig;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -8,26 +9,26 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.Rarity;
 
 public class ModItems {
-    public static final Item FLIMSY_WINGS = registerItem("flimsy_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(54), 0.7f, 0.3f, 0.2f, 0f, 0f, false, false));
-    public static final Item FLEDGLING_WINGS = registerItem("fledgling_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(47), 0.8f, 0f, 0f, 0.3f, 0.2f, false, false));
-    public static final Item PHANTOM_WINGS = registerItem("phantom_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(130), 1f, 0.3f, 0.29f, 0f, 0f, false, false));
-    public static final Item LEAF_WINGS = registerItem("leaf_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(122), 0.9f, 0.3f, 0.28f, 0.6f, 0.2f, false, false));
-    public static final Item CORAL_WINGS = registerItem("coral_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(370), 1f, 0.6f, 0.22f, 2f, 0.22f, true, false));
-    public static final Item BEE_WINGS = registerItem("bee_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(235), 0.8f, 0.36f, 0.22f, 1.8f, 0.18f, false, false));
-    public static final Item MOTH_WINGS = registerItem("moth_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(324), 1f, 0.66f, 0.24f, 0.8f, 0.16f, false, false));
-    public static final Item DEMON_WINGS = registerItem("demon_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(145), 1.1f, 0.35f, 0.22f, 1.4f, 0.2f, false, false));
-    public static final Item BLAZE_WINGS = registerItem("blaze_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(478).rarity(Rarity.UNCOMMON), 1.3f, 0.5f, 0.32f, 2.2f, 0.17f, false, false));
-    public static final Item GEM_WINGS = registerItem("gem_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(611), 1.2f, 0.4f, 0.28f, 0.7f, 0.2f, false, false));
-    public static final Item VOID_WINGS = registerItem("void_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(1100).rarity(Rarity.UNCOMMON), 1.3f, 0.72f, 0.34f, 1.8f, 0.14f, false, false));
-    public static final Item ELYTRA_WINGS = registerItem("elytra_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(1620).rarity(Rarity.UNCOMMON), 1.1f, 0f, 0f, 0f, 0f, false, true));
-    public static final Item PRISTINE_WINGS = registerItem("pristine_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(2120).fireproof().rarity(Rarity.RARE), 1.5f, 1.4f, 0.41f, 4f, 0.16f, true, true));
-    public static final Item NEBULOUS_WINGS = registerItem("nebulous_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(2034).rarity(Rarity.RARE), 1.65f, 1.84f, 0.502f, 9999f, 0.1f, true, false));
+    public static final Item FLIMSY_WINGS = registerItem("flimsy_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.flimsyWings));
+    public static final Item FLEDGLING_WINGS = registerItem("fledgling_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.fledglingWings));
+    public static final Item PHANTOM_WINGS = registerItem("phantom_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.phantomWings));
+    public static final Item LEAF_WINGS = registerItem("leaf_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.leafWings));
+    public static final Item CORAL_WINGS = registerItem("coral_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.coralWings));
+    public static final Item BEE_WINGS = registerItem("bee_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.beeWings));
+    public static final Item MOTH_WINGS = registerItem("moth_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.mothWings));
+    public static final Item DEMON_WINGS = registerItem("demon_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.demonWings));
+    public static final Item BLAZE_WINGS = registerItem("blaze_wings", new WingsItem(new WingsItem.Settings().rarity(Rarity.UNCOMMON), WingsConfig.INSTANCE.blazeWings));
+    public static final Item GEM_WINGS = registerItem("gem_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.gemWings));
+    public static final Item VOID_WINGS = registerItem("void_wings", new WingsItem(new WingsItem.Settings().rarity(Rarity.UNCOMMON), WingsConfig.INSTANCE.voidWings));
+    public static final Item ELYTRA_WINGS = registerItem("elytra_wings", new WingsItem(new WingsItem.Settings().rarity(Rarity.UNCOMMON), WingsConfig.INSTANCE.elytraWings));
+    public static final Item PRISTINE_WINGS = registerItem("pristine_wings", new WingsItem(new WingsItem.Settings().fireproof().rarity(Rarity.RARE), WingsConfig.INSTANCE.pristineWings));
+    public static final Item NEBULOUS_WINGS = registerItem("nebulous_wings", new WingsItem(new WingsItem.Settings().rarity(Rarity.RARE), WingsConfig.INSTANCE.nebulousWings));
 
-    public static final Item ASLERIX_WINGS = registerItem("aslerix_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(2170).fireproof().rarity(Rarity.RARE), 1.6f, 2.1f, 0.3f, 9999f, 0.11f, true, true));
-    public static final Item HAZEL_WINGS = registerItem("hazel_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(2140).fireproof().rarity(Rarity.RARE), 1.6f, 1.02f, 0.47f, 2f, 0.17f, true, true));
+    public static final Item ASLERIX_WINGS = registerItem("aslerix_wings", new WingsItem(new WingsItem.Settings().fireproof().rarity(Rarity.RARE), WingsConfig.INSTANCE.aslerixWings));
+    public static final Item HAZEL_WINGS = registerItem("hazel_wings", new WingsItem(new WingsItem.Settings().fireproof().rarity(Rarity.RARE), WingsConfig.INSTANCE.hazelWings));
 
-    public static final Item MECHANICAL_WINGS = registerItem("mechanical_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(220), 1.1f, 0.5f, 0.26f, 1.2f, 0.17f, false, false));
-    public static final Item BRASS_WINGS = registerItem("brass_wings", new WingsItem(new WingsItem.Settings().maxCount(1).maxDamage(2300).rarity(Rarity.RARE), 1.55f, 9f, 0.3f, 9999f, 0.2f, true, false));
+    public static final Item MECHANICAL_WINGS = registerItem("mechanical_wings", new WingsItem(new WingsItem.Settings(), WingsConfig.INSTANCE.mechanicalWings));
+    public static final Item BRASS_WINGS = registerItem("brass_wings", new WingsItem(new WingsItem.Settings().rarity(Rarity.RARE), WingsConfig.INSTANCE.brassWings));
 
     private static Item registerItem(String name, Item item) {
         return Registry.register(Registries.ITEM, Identifier.of(HazelsVariousWings.MOD_ID, name), item);

--- a/src/main/java/hazelclover/hazelsvariouswings/item/ModTags.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/item/ModTags.java
@@ -1,0 +1,43 @@
+package hazelclover.hazelsvariouswings.item;
+
+import hazelclover.hazelsvariouswings.HazelsVariousWings;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
+import net.minecraft.item.Item;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ModTags extends FabricTagProvider<Item> {
+    public static final TagKey<Item> WINGS = TagKey.of(RegistryKeys.ITEM, Identifier.of(HazelsVariousWings.MOD_ID, "wings"));
+
+    public ModTags(FabricDataOutput output, CompletableFuture<RegistryWrapper.WrapperLookup> registriesFuture) {
+        super(output, RegistryKeys.ITEM, registriesFuture);
+    }
+
+    @Override
+    protected void configure(RegistryWrapper.WrapperLookup wrapperLookup) {
+        getOrCreateTagBuilder(WINGS)
+                .add(ModItems.FLIMSY_WINGS)
+                .add(ModItems.FLEDGLING_WINGS)
+                .add(ModItems.PHANTOM_WINGS)
+                .add(ModItems.LEAF_WINGS)
+                .add(ModItems.CORAL_WINGS)
+                .add(ModItems.BEE_WINGS)
+                .add(ModItems.MOTH_WINGS)
+                .add(ModItems.DEMON_WINGS)
+                .add(ModItems.BLAZE_WINGS)
+                .add(ModItems.GEM_WINGS)
+                .add(ModItems.VOID_WINGS)
+                .add(ModItems.ELYTRA_WINGS)
+                .add(ModItems.PRISTINE_WINGS)
+                .add(ModItems.NEBULOUS_WINGS)
+                .add(ModItems.ASLERIX_WINGS)
+                .add(ModItems.HAZEL_WINGS)
+                .add(ModItems.MECHANICAL_WINGS)
+                .add(ModItems.BRASS_WINGS);
+    }
+}

--- a/src/main/java/hazelclover/hazelsvariouswings/item/WingsItem.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/item/WingsItem.java
@@ -98,7 +98,7 @@ public class WingsItem extends TrinketItem implements TrinketRenderer {
 
     @Override
     public void appendTooltip(ItemStack stack, TooltipContext context, List<Text> tooltip, TooltipType type) {
-        if (config.doesGlide) {tooltip.add(Text.translatable("tooltip.hazels-various-wings.wingsitem.doesGlide").formatted(Formatting.LIGHT_PURPLE));}
+        if (config.doesGlide.get()) {tooltip.add(Text.translatable("tooltip.hazels-various-wings.wingsitem.doesGlide").formatted(Formatting.LIGHT_PURPLE));}
         tooltip.add(Text.translatable("tooltip.hazels-various-wings.wingsitem.generic").formatted(Formatting.GRAY));
         super.appendTooltip(stack, context, tooltip, type);
     }
@@ -160,11 +160,11 @@ public class WingsItem extends TrinketItem implements TrinketRenderer {
             }
             case HOVER -> {
                 sYawBaseAngle = 0.7f;
-                sYawFlapSpeed = 0.0f;
-                sYawFlapAngle = 0.0f;
-                sPitchBaseAngle = 0.0f;
-                sPitchFlapSpeed = 0.0f;
-                sPitchFlapAngle = 0.0f;
+                sYawFlapSpeed = 0.6f;
+                sYawFlapAngle = 0.4f;
+                sPitchBaseAngle = 0.3f;
+                sPitchFlapSpeed = 0.6f;
+                sPitchFlapAngle = -0.5f;
                 sRotBaseAngle = 0.9f;
                 sRotFlapSpeed = 0.0f;
                 sRotFlapAngle = 0.0f;

--- a/src/main/java/hazelclover/hazelsvariouswings/item/WingsItem.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/item/WingsItem.java
@@ -4,6 +4,7 @@ import dev.emi.trinkets.api.SlotReference;
 import dev.emi.trinkets.api.TrinketItem;
 import dev.emi.trinkets.api.client.TrinketRenderer;
 import dev.emi.trinkets.api.client.TrinketRendererRegistry;
+import hazelclover.hazelsvariouswings.config.WingsConfig;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.OverlayTexture;
@@ -30,18 +31,11 @@ import java.util.List;
 import static java.lang.Math.*;
 
 public class WingsItem extends TrinketItem implements TrinketRenderer {
-    private final float scale;
+    public final WingsConfig.WingConfig config;
     public float setFallDistOnServer = -1;
 
-    public final float flyDuration;
-    public final float flyPower;
-    public final float hoverDuration;
-    public final float hoverPower;
     public float currentFlyDuration;
     public float currentHoverDuration;
-
-    public final boolean inWaterFunctional;
-    public final boolean doesGlide;
 
     public int flightHeldTicks = 0;
     public float damageItemTimer = 1;
@@ -52,18 +46,10 @@ public class WingsItem extends TrinketItem implements TrinketRenderer {
 
     public WingsFlightState flightState = WingsFlightState.GROUNDED;
 
-    public WingsItem(Settings settings, float scale, float flyDuration, float flyPower, float hoverDuration, float hoverPower, boolean inWaterFunctional, boolean doesGlide) {
-        super(settings);
-        TrinketRendererRegistry.registerRenderer(this, (TrinketRenderer) this);
-        this.scale = scale;
-        this.flyDuration = flyDuration;
-        this.flyPower = flyPower;
-        this.hoverDuration = hoverDuration;
-        this.hoverPower = hoverPower;
-        this.currentFlyDuration = flyDuration;
-        this.currentHoverDuration = hoverDuration;
-        this.inWaterFunctional = inWaterFunctional;
-        this.doesGlide = doesGlide;
+    public WingsItem(Settings settings, WingsConfig.WingConfig config) {
+        super(settings.maxCount(1).maxDamage(config.durability));
+        TrinketRendererRegistry.registerRenderer(this, this);
+        this.config = config;
     }
 
 
@@ -112,7 +98,7 @@ public class WingsItem extends TrinketItem implements TrinketRenderer {
 
     @Override
     public void appendTooltip(ItemStack stack, TooltipContext context, List<Text> tooltip, TooltipType type) {
-        if (doesGlide) {tooltip.add(Text.translatable("tooltip.hazels-various-wings.wingsitem.doesGlide").formatted(Formatting.LIGHT_PURPLE));}
+        if (config.doesGlide) {tooltip.add(Text.translatable("tooltip.hazels-various-wings.wingsitem.doesGlide").formatted(Formatting.LIGHT_PURPLE));}
         tooltip.add(Text.translatable("tooltip.hazels-various-wings.wingsitem.generic").formatted(Formatting.GRAY));
         super.appendTooltip(stack, context, tooltip, type);
     }
@@ -207,6 +193,7 @@ public class WingsItem extends TrinketItem implements TrinketRenderer {
         float yaw = (float) (sYawFlapAngle * sin(sYawFlapSpeed * animationProgress) + sYawBaseAngle);
         float pitch = (float) (sPitchFlapAngle * sin(sPitchFlapSpeed * animationProgress) + sPitchBaseAngle);
         float rot = (float) (sRotFlapAngle * sin(sRotFlapSpeed * animationProgress) + sRotBaseAngle);
+        float scale = config.scale;
         matrices.scale(scale, scale, scale);
         matrices.translate(-0.5+(0.14f/scale), -0.18f/scale, 0.3f/scale); // X right-left Y up-down Z forwards-backwards
         matrices.multiply(RotationAxis.POSITIVE_X.rotation((float) (PI + rot))); // flip right way up

--- a/src/main/java/hazelclover/hazelsvariouswings/loot/TraderTrades.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/loot/TraderTrades.java
@@ -14,15 +14,13 @@ public class TraderTrades {
     public static void register() {
         HazelsVariousWings.LOGGER.info("Registering Wandering Trader trades for " + HazelsVariousWings.MOD_ID);
         // Adding wing trades to Wandering Trader
-        TradeOfferHelper.registerWanderingTraderOffers(1, factories -> {
-            factories.add((entity, random) -> new TradeOffer(
-                    new TradedItem(Items.EMERALD, 4),
-                    new ItemStack(ModItems.FLEDGLING_WINGS, 1),
-                    1,                                   // Max uses of the trade
-                    5,                                   // Experience given
-                    0.1F                                // Price multiplier
-            ));
-        });
+        TradeOfferHelper.registerWanderingTraderOffers(1, factories -> factories.add((entity, random) -> new TradeOffer(
+                new TradedItem(Items.EMERALD, 4),
+                new ItemStack(ModItems.FLEDGLING_WINGS, 1),
+                1,                                   // Max uses of the trade
+                5,                                   // Experience given
+                0.1F                                // Price multiplier
+        )));
         TradeOfferHelper.registerWanderingTraderOffers(2, factories -> {
             factories.add((entity, random) -> new TradeOffer(
                     new TradedItem(Items.EMERALD, 12),

--- a/src/main/java/hazelclover/hazelsvariouswings/mixin/EndCityShipElytraReplacer.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/mixin/EndCityShipElytraReplacer.java
@@ -1,15 +1,17 @@
 package hazelclover.hazelsvariouswings.mixin;
 
+import hazelclover.hazelsvariouswings.config.GeneralConfig;
 import hazelclover.hazelsvariouswings.item.ModItems;
 import net.minecraft.entity.decoration.ItemFrameEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.structure.EndCityGenerator;
 import net.minecraft.util.math.BlockBox;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.ServerWorldAccess;
-import org.objectweb.asm.tree.InnerClassNode;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -24,13 +26,19 @@ public class EndCityShipElytraReplacer {
 	 */
 	@Inject(method = "handleMetadata", at = @At("HEAD"), cancellable = true)
 	private void handleMetadata(String metadata, BlockPos pos, ServerWorldAccess world, Random random, BlockBox boundingBox, CallbackInfo ci) {
-		if (metadata.startsWith("Elytra")) {
-			EndCityGenerator.Piece piece = (EndCityGenerator.Piece) (Object) this;
-			ItemFrameEntity itemFrameEntity = new ItemFrameEntity(world.toServerWorld(), pos, piece.getPlacementData().getRotation().rotate(Direction.SOUTH));
-			itemFrameEntity.setHeldItemStack(new ItemStack(ModItems.ELYTRA_WINGS), false);
-			world.spawnEntity(itemFrameEntity);
+		if (GeneralConfig.INSTANCE.replaceElytraInEndCityShip.get()) {
+			if (metadata.startsWith("Elytra")) {
+				EndCityGenerator.Piece piece = (EndCityGenerator.Piece) (Object) this;
+				ItemFrameEntity itemFrameEntity = new ItemFrameEntity(world.toServerWorld(), pos, piece.getPlacementData().getRotation().rotate(Direction.SOUTH));
+				Item item = world.getRegistryManager().get(RegistryKeys.ITEM).get(GeneralConfig.INSTANCE.replaceElytraInEndCityShipWith.get());
+				if (item == null) {
+					item = ModItems.ELYTRA_WINGS;
+				}
+				itemFrameEntity.setHeldItemStack(new ItemStack(item), false);
+				world.spawnEntity(itemFrameEntity);
 
-			ci.cancel();
+				ci.cancel();
+			}
 		}
 	}
 }

--- a/src/main/java/hazelclover/hazelsvariouswings/mixin/FireworkRocketItemUseWithWings.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/mixin/FireworkRocketItemUseWithWings.java
@@ -1,0 +1,38 @@
+package hazelclover.hazelsvariouswings.mixin;
+
+import hazelclover.hazelsvariouswings.config.GeneralConfig;
+import hazelclover.hazelsvariouswings.fuctionality.WingsHandler;
+import hazelclover.hazelsvariouswings.item.WingsItem;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.FireworkRocketItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(FireworkRocketItem.class)
+public class FireworkRocketItemUseWithWings {
+    /**
+     * @reason Hazel's Various Wings needs to disable firework rocket use if canUseFirework setting is false
+     * @author D3v1s0m
+     */
+    @Inject(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;isFallFlying()Z", shift = At.Shift.AFTER), cancellable = true)
+    private void handleMetadata(World world, PlayerEntity user, Hand hand, CallbackInfoReturnable<TypedActionResult<ItemStack>> cir) {
+        ItemStack itemStack = user.getEquippedStack(EquipmentSlot.CHEST);
+        WingsItem wings = WingsHandler.getEquippedWings(user);
+        if (itemStack.isOf(Items.ELYTRA) && (GeneralConfig.INSTANCE.disableVanillaElytra.get() || !GeneralConfig.INSTANCE.canUseFireworks.get()) && wings == null) {
+            cir.setReturnValue(TypedActionResult.pass(user.getStackInHand(hand)));
+        } else {
+            if (wings != null && wings.config.doesGlide.get() && !wings.config.canUseFireworks.get()) {
+                cir.setReturnValue(TypedActionResult.pass(user.getStackInHand(hand)));
+            }
+        }
+    }
+
+}

--- a/src/main/java/hazelclover/hazelsvariouswings/mixin/LivingEntityTickFallFlyingWingCheck.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/mixin/LivingEntityTickFallFlyingWingCheck.java
@@ -1,8 +1,8 @@
 package hazelclover.hazelsvariouswings.mixin;
 
+import hazelclover.hazelsvariouswings.config.GeneralConfig;
 import hazelclover.hazelsvariouswings.fuctionality.WingsHandler;
 import hazelclover.hazelsvariouswings.item.WingsItem;
-import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffects;
@@ -10,7 +10,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ElytraItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
 import net.minecraft.world.event.GameEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -30,19 +29,36 @@ public class LivingEntityTickFallFlyingWingCheck {
 
         boolean bl = invoker.invokeGetFlag(7);
         if (bl && !entity.isOnGround() && !entity.hasVehicle() && !entity.hasStatusEffect(StatusEffects.LEVITATION)) {
-            bl = false;
-            if (entity instanceof PlayerEntity player) {
-                WingsItem wings = WingsHandler.getEquippedWings(player);
-                if (wings != null && wings.doesGlide) {
-                    bl = true;
+            ItemStack itemStack = entity.getEquippedStack(EquipmentSlot.CHEST);
+            if (itemStack.isOf(Items.ELYTRA) && ElytraItem.isUsable(itemStack)) {
+                if (!GeneralConfig.INSTANCE.disableVanillaElytra) {
                     int i = entity.getFallFlyingTicks() + 1;
                     if (!entity.getWorld().isClient && i % 10 == 0) {
+                        int j = i / 10;
+                        if (j % 2 == 0) {
+                            itemStack.damage(1, entity, EquipmentSlot.CHEST);
+                        }
+
+                        entity.emitGameEvent(GameEvent.ELYTRA_GLIDE);
+                    }
+                } else {
+                    bl = false;
+                }
+            }  else {
+                bl = false;
+                if (entity instanceof PlayerEntity player) {
+                    WingsItem wings = WingsHandler.getEquippedWings(player);
+                    if (wings != null && wings.config.doesGlide) {
+                        bl = true;
+                        int i = entity.getFallFlyingTicks() + 1;
+                        if (!entity.getWorld().isClient && i % 10 == 0) {
 //                        int j = i / 10;
 //                        if (j % 2 == 0) {
 //                            itemStack.damage(1, entity, EquipmentSlot.CHEST);
 //                        }
 
-                        entity.emitGameEvent(GameEvent.ELYTRA_GLIDE);
+                            entity.emitGameEvent(GameEvent.ELYTRA_GLIDE);
+                        }
                     }
                 }
             }

--- a/src/main/java/hazelclover/hazelsvariouswings/mixin/LivingEntityTickFallFlyingWingCheck.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/mixin/LivingEntityTickFallFlyingWingCheck.java
@@ -29,9 +29,21 @@ public class LivingEntityTickFallFlyingWingCheck {
 
         boolean bl = invoker.invokeGetFlag(7);
         if (bl && !entity.isOnGround() && !entity.hasVehicle() && !entity.hasStatusEffect(StatusEffects.LEVITATION)) {
-            ItemStack itemStack = entity.getEquippedStack(EquipmentSlot.CHEST);
-            if (itemStack.isOf(Items.ELYTRA) && ElytraItem.isUsable(itemStack)) {
-                if (!GeneralConfig.INSTANCE.disableVanillaElytra) {
+            bl = false;
+            if (entity instanceof PlayerEntity player) {
+                WingsItem wings = WingsHandler.getEquippedWings(player);
+                if (wings != null && wings.config.doesGlide.get()) {
+                    bl = true;
+                    int i = entity.getFallFlyingTicks() + 1;
+                    if (!entity.getWorld().isClient && i % 10 == 0) {
+                        entity.emitGameEvent(GameEvent.ELYTRA_GLIDE);
+                    }
+                }
+            }
+            if (!bl) {
+                ItemStack itemStack = entity.getEquippedStack(EquipmentSlot.CHEST);
+                if (itemStack.isOf(Items.ELYTRA) && ElytraItem.isUsable(itemStack) && !GeneralConfig.INSTANCE.disableVanillaElytra.get()) {
+                    bl = true;
                     int i = entity.getFallFlyingTicks() + 1;
                     if (!entity.getWorld().isClient && i % 10 == 0) {
                         int j = i / 10;
@@ -40,25 +52,6 @@ public class LivingEntityTickFallFlyingWingCheck {
                         }
 
                         entity.emitGameEvent(GameEvent.ELYTRA_GLIDE);
-                    }
-                } else {
-                    bl = false;
-                }
-            }  else {
-                bl = false;
-                if (entity instanceof PlayerEntity player) {
-                    WingsItem wings = WingsHandler.getEquippedWings(player);
-                    if (wings != null && wings.config.doesGlide) {
-                        bl = true;
-                        int i = entity.getFallFlyingTicks() + 1;
-                        if (!entity.getWorld().isClient && i % 10 == 0) {
-//                        int j = i / 10;
-//                        if (j % 2 == 0) {
-//                            itemStack.damage(1, entity, EquipmentSlot.CHEST);
-//                        }
-
-                            entity.emitGameEvent(GameEvent.ELYTRA_GLIDE);
-                        }
                     }
                 }
             }

--- a/src/main/java/hazelclover/hazelsvariouswings/mixin/PlayerEntityCheckFallFlyingHasWings.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/mixin/PlayerEntityCheckFallFlyingHasWings.java
@@ -1,21 +1,11 @@
 package hazelclover.hazelsvariouswings.mixin;
 
 import hazelclover.hazelsvariouswings.fuctionality.WingsHandler;
-import hazelclover.hazelsvariouswings.item.ModItems;
 import hazelclover.hazelsvariouswings.item.WingsItem;
-import net.minecraft.entity.decoration.ItemFrameEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.structure.EndCityGenerator;
-import net.minecraft.util.math.BlockBox;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.random.Random;
-import net.minecraft.world.ServerWorldAccess;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 
@@ -28,7 +18,7 @@ public class PlayerEntityCheckFallFlyingHasWings {
 	@Inject(method = "checkFallFlying", at = @At("HEAD"), cancellable = true)
 	private void handleMetadata(CallbackInfoReturnable<Boolean> cir) {
 		WingsItem wings = WingsHandler.getEquippedWings((PlayerEntity) (Object) this);
-		if (wings == null || !wings.doesGlide) {return;}
+		if (wings == null || !wings.config.doesGlide) {return;}
 		cir.setReturnValue(true);
 		cir.cancel();
 	}

--- a/src/main/java/hazelclover/hazelsvariouswings/mixin/PlayerEntityCheckFallFlyingHasWings.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/mixin/PlayerEntityCheckFallFlyingHasWings.java
@@ -18,8 +18,7 @@ public class PlayerEntityCheckFallFlyingHasWings {
 	@Inject(method = "checkFallFlying", at = @At("HEAD"), cancellable = true)
 	private void handleMetadata(CallbackInfoReturnable<Boolean> cir) {
 		WingsItem wings = WingsHandler.getEquippedWings((PlayerEntity) (Object) this);
-		if (wings == null || !wings.config.doesGlide) {return;}
+		if (wings == null || !wings.config.doesGlide.get()) {return;}
 		cir.setReturnValue(true);
-		cir.cancel();
 	}
 }

--- a/src/main/java/hazelclover/hazelsvariouswings/mixin/PlayerStartFallFlyingWithWings.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/mixin/PlayerStartFallFlyingWithWings.java
@@ -1,11 +1,8 @@
 package hazelclover.hazelsvariouswings.mixin;
 
-import hazelclover.hazelsvariouswings.HazelsVariousWings;
 import hazelclover.hazelsvariouswings.fuctionality.WingsHandler;
 import hazelclover.hazelsvariouswings.item.WingsItem;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.item.ElytraItem;
-import net.minecraft.item.Items;
 import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,7 +21,7 @@ public class PlayerStartFallFlyingWithWings {
 
         if (player.input.jumping && !player.hasVehicle() && !player.isClimbing()) {
             WingsItem wings = WingsHandler.getEquippedWings(player);
-            if (wings != null && wings.doesGlide && player.checkFallFlying()) {
+            if (wings != null && wings.config.doesGlide && player.checkFallFlying()) {
                 player.networkHandler.sendPacket(new ClientCommandC2SPacket(player, ClientCommandC2SPacket.Mode.START_FALL_FLYING));
             }
         }

--- a/src/main/java/hazelclover/hazelsvariouswings/mixin/PlayerStartFallFlyingWithWings.java
+++ b/src/main/java/hazelclover/hazelsvariouswings/mixin/PlayerStartFallFlyingWithWings.java
@@ -21,7 +21,7 @@ public class PlayerStartFallFlyingWithWings {
 
         if (player.input.jumping && !player.hasVehicle() && !player.isClimbing()) {
             WingsItem wings = WingsHandler.getEquippedWings(player);
-            if (wings != null && wings.config.doesGlide && player.checkFallFlying()) {
+            if (wings != null && wings.config.doesGlide.get() && player.checkFallFlying()) {
                 player.networkHandler.sendPacket(new ClientCommandC2SPacket(player, ClientCommandC2SPacket.Mode.START_FALL_FLYING));
             }
         }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,9 +32,10 @@
 		"fabricloader": ">=0.16.5",
 		"minecraft": "~1.21.1",
 		"java": ">=21",
-		"fabric-api": "*"
+		"fabric-api": "*",
+		"trinkets": ">=${trinkets_version}",
+		"fzzy_config": ">=${fzzy_config_version}"
 	},
 	"suggests": {
-		"another-mod": "*"
 	}
 }

--- a/src/main/resources/hazels-various-wings.mixins.json
+++ b/src/main/resources/hazels-various-wings.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "EndCityShipElytraReplacer",
     "EntityGetSetFlagInvoker",
+    "FireworkRocketItemUseWithWings",
     "PlayerEntityCheckFallFlyingHasWings"
   ],
   "injectors": {


### PR DESCRIPTION
This PR introduces an in-game configuration for customizing wings using the [Fzzy Config](https://modrinth.com/mod/fzzy-config) mod (now a required dependency). Server admins (op level 3) can adjust properties like durability, scale, flight duration, and more. It also adds the ability to configure the replacement of the vanilla elytra with custom wings in End City Ships. The config automatically integrates with Mod Menu, and server admins can also use the `/configure hazels-various-wings` command to open the config GUI. This update provides greater flexibility and control over wing customization.